### PR TITLE
Add basic markdown blogging

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,24 @@
+import { getAllPostsMeta, getPostBySlug } from "@/lib/posts"
+import { formatDate } from "@/lib/utils"
+
+interface Params {
+  slug: string
+}
+
+export async function generateStaticParams() {
+  return getAllPostsMeta().map((post) => ({ slug: post.slug }))
+}
+
+export default function BlogPostPage({ params }: { params: Params }) {
+  const post = getPostBySlug(params.slug)
+  return (
+    <main className="container mx-auto px-4 py-12 mt-16">
+      <h1 className="text-3xl font-bold mb-4">{post.title}</h1>
+      <p className="text-sm text-gray-500 mb-4">{formatDate(post.date)}</p>
+      <article
+        className="prose prose-gray"
+        dangerouslySetInnerHTML={{ __html: post.content }}
+      />
+    </main>
+  )
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link"
+import { getAllPostsMeta } from "@/lib/posts"
+import { formatDate } from "@/lib/utils"
+
+export const metadata = {
+  title: "Blog"
+}
+
+export default function BlogPage() {
+  const posts = getAllPostsMeta()
+  return (
+    <main className="container mx-auto px-4 py-12 mt-16">
+      <h1 className="text-3xl font-bold mb-8">Blog</h1>
+      <ul className="space-y-8">
+        {posts.map((post) => (
+          <li key={post.slug}>
+            <Link href={`/blog/${post.slug}`} className="text-2xl font-semibold hover:underline">
+              {post.title}
+            </Link>
+            <p className="text-sm text-gray-500">{formatDate(post.date)}</p>
+            {post.summary && <p className="text-gray-700">{post.summary}</p>}
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,17 @@
 import BlogCard from "@/components/blog-card"
 import Hero from "@/components/hero"
-import { blogPosts } from "@/lib/data"
+import { getAllPostsMeta } from "@/lib/posts"
 
 export default function Home() {
+  const posts = getAllPostsMeta().slice(0, 3)
   return (
     <main className="min-h-screen">
       <Hero />
       <section className="container mx-auto px-4 py-12">
         <h2 className="text-3xl font-bold mb-8">Latest Posts</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {blogPosts.map((post) => (
-            <BlogCard key={post.id} post={post} />
+          {posts.map((post) => (
+            <BlogCard key={post.slug} post={post} />
           ))}
         </div>
       </section>

--- a/content/posts/another-post.md
+++ b/content/posts/another-post.md
@@ -1,0 +1,10 @@
+---
+title: "Another Post"
+date: "2024-05-02"
+summary: "Another sample blog post"
+slug: "another-post"
+---
+
+## Another Post
+
+This is another example post.

--- a/content/posts/hello-world.md
+++ b/content/posts/hello-world.md
@@ -1,0 +1,10 @@
+---
+title: "Hello World"
+date: "2024-05-01"
+summary: "My first post with Next.js"
+slug: "hello-world"
+---
+
+# Hello World
+
+Welcome to my blog built with Next.js and Tailwind CSS.

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,0 +1,74 @@
+import fs from 'fs'
+import path from 'path'
+
+export interface PostMeta {
+  title: string
+  date: string
+  slug: string
+  summary?: string
+}
+
+export interface Post extends PostMeta {
+  content: string
+}
+
+const postsDirectory = path.join(process.cwd(), 'content/posts')
+
+function parseFrontMatter(file: string) {
+  const match = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/m.exec(file)
+  let data: Record<string, string> = {}
+  let content = file
+  if (match) {
+    const yaml = match[1]
+    content = match[2]
+    yaml.split(/\r?\n/).forEach((line) => {
+      const idx = line.indexOf(':')
+      if (idx !== -1) {
+        const key = line.slice(0, idx).trim()
+        const value = line.slice(idx + 1).trim()
+        data[key] = value.replace(/^"|"$/g, '')
+      }
+    })
+  }
+  return { data, content }
+}
+
+function markdownToHtml(src: string) {
+  return src
+    .split(/\r?\n/) 
+    .map((line) => {
+      if (/^#\s+/.test(line)) {
+        return `<h1>${line.replace(/^#\s+/, '')}</h1>`
+      }
+      if (/^##\s+/.test(line)) {
+        return `<h2>${line.replace(/^##\s+/, '')}</h2>`
+      }
+      if (line.trim() === '') return ''
+      return `<p>${line}</p>`
+    })
+    .join('\n')
+}
+
+export function getPostSlugs(): string[] {
+  return fs.readdirSync(postsDirectory).filter((f) => f.endsWith('.md')).map((f) => f.replace(/\.md$/, ''))
+}
+
+export function getPostBySlug(slug: string): Post {
+  const fullPath = path.join(postsDirectory, `${slug}.md`)
+  const file = fs.readFileSync(fullPath, 'utf8')
+  const { data, content } = parseFrontMatter(file)
+  return {
+    title: data.title || '',
+    date: data.date || '',
+    slug: data.slug || slug,
+    summary: data.summary || '',
+    content: markdownToHtml(content),
+  }
+}
+
+export function getAllPostsMeta(): PostMeta[] {
+  return getPostSlugs()
+    .map((slug) => getPostBySlug(slug))
+    .map(({ content, ...meta }) => meta)
+    .sort((a, b) => (a.date > b.date ? -1 : 1))
+}


### PR DESCRIPTION
## Summary
- parse markdown posts from `content/posts` using custom parser
- list posts on `/blog`
- display post details on `/blog/[slug]`
- show recent posts on the home page

## Testing
- `pnpm lint` *(fails: ESLint is not configured)*
- `pnpm build` *(fails: failed to fetch fonts during build)*

------
https://chatgpt.com/codex/tasks/task_e_6844f32fb408832db2f1a545c8ec539e