### PR TITLE
Fix invalid date handling in utils

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -7,6 +7,7 @@ export function cn(...inputs: ClassValue[]) {
 
 export function formatDate(dateString: string): string {
   const date = new Date(dateString)
+  if (isNaN(date.getTime())) return dateString
   return new Intl.DateTimeFormat("en-US", {
     year: "numeric",
     month: "long",


### PR DESCRIPTION
## Summary
- handle invalid dates gracefully in `formatDate`

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run build` *(fails: can't fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6844f58a94fc832d897492183c2439e4